### PR TITLE
Fix regular expression

### DIFF
--- a/app/sw/beer-service-worker.js
+++ b/app/sw/beer-service-worker.js
@@ -2,7 +2,7 @@ self.importScripts('/jszip.js');
 
 const config = {
   version: 'suzuki-5',
-  epubPattern: /___\/(\w+)\/(.*)$/,
+  epubPattern: /___\/([\-\w]+)\/(.*)$/,
   cachePattern: /\.(?:css|js|jpg|png|svg|ttf|woff|eot|otf|html|xhtml|mp3|m4a)$/,
   debug: true
 };


### PR DESCRIPTION
The epub hash function can return negative integers.
It's really difficult to have numeric hash function which ensure a
positive result.
So we need to adapt regular expression to handle '-' case in the url.